### PR TITLE
Force output as UTF-8

### DIFF
--- a/telegram.pl
+++ b/telegram.pl
@@ -29,6 +29,7 @@ use IO::Select;
 use JSON;
 use Config::Simple;
 use Errno qw/EAGAIN EWOULDBLOCK/;
+use encoding 'utf8';
 
 my $cfgfile = $ENV{HOME}."/.irssi/telegram.cfg";
 


### PR DESCRIPTION
Before adding this, a string like "AÄ OÖ aå" was sent to Telegram as "AÃ OÃ aÃ¥". At this point content of $encoded was stored as "A33240O33260a332%A5" (under telegram_send_message($$)). Receiving from Telegram works before and after adding this.

TODO: is "use encoding 'utf8';" the best way? Why does not "use utf8;" work?